### PR TITLE
Added way to write binary files

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -387,6 +387,15 @@ func readData(r *bufio.Reader, order binary.ByteOrder) (kobj *K, err error) {
 	return nil, ErrBadMsg
 }
 
+func ReadFromBuffer(data *bytes.Buffer) (*K, error) {
+	var order = binary.LittleEndian
+	reader := bufio.NewReader(data)
+	// Read 0xFF, 0x01 bytes magic number
+	reader.ReadByte()
+	reader.ReadByte()
+	return readData(reader, order)
+}
+
 func ReadFromFile(filename string) (*K, error) {
 	var order = binary.LittleEndian
 	f, err := os.Open(filename)

--- a/decode.go
+++ b/decode.go
@@ -6,11 +6,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"os"
 	"reflect"
 	"time"
 	"unsafe"
 
-	"github.com/nu7hatch/gouuid"
+	uuid "github.com/nu7hatch/gouuid"
 )
 
 var typeSize = []int{
@@ -384,4 +385,17 @@ func readData(r *bufio.Reader, order binary.ByteOrder) (kobj *K, err error) {
 		return nil, errors.New(errmsg)
 	}
 	return nil, ErrBadMsg
+}
+
+func ReadFromFile(filename string) (*K, error) {
+	var order = binary.LittleEndian
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(f)
+	// Read 0xFF, 0x01 bytes magic number
+	reader.ReadByte()
+	reader.ReadByte()
+	return readData(reader, order)
 }

--- a/encode.go
+++ b/encode.go
@@ -158,6 +158,18 @@ func Encode(w io.Writer, msgtype ReqType, data *K) error {
 	return err
 }
 
+func WriteToBuffer(data *K) (*bytes.Buffer, error) {
+	var order = binary.LittleEndian
+	buf := new(bytes.Buffer)
+
+	buf.Write([]byte{0xFF, 0x01})
+	if err := writeData(buf, order, data); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
 func WriteToFile(filename string, data *K) error {
 	var order = binary.LittleEndian
 	buf := new(bytes.Buffer)

--- a/encode.go
+++ b/encode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -155,4 +156,23 @@ func Encode(w io.Writer, msgtype ReqType, data *K) error {
 
 	_, err := w.Write(Compress(b))
 	return err
+}
+
+func WriteToFile(filename string, data *K) error {
+	var order = binary.LittleEndian
+	buf := new(bytes.Buffer)
+
+	buf.Write([]byte{0xFF, 0x01})
+	if err := writeData(buf, order, data); err != nil {
+		return err
+	}
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	f.Write(buf.Bytes())
+	defer f.Close()
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sv/kdbgo
 
+go 1.18
+
 require github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=


### PR DESCRIPTION
I created two functions to parse and write binary files. They can be imported into q using the load command.

```go
err = kdb.WriteToFile("data.kdb", kdbTable)
```

and then in q

```q
get`:data.kdb
```